### PR TITLE
fix memory deallocation error

### DIFF
--- a/src/cusz.cu
+++ b/src/cusz.cu
@@ -138,15 +138,15 @@ int main(int argc, char** argv)
 
     //wenyu's modification
     //invoke system() to untar archived files first before decompression
-    /*
+   
     if (ap->to_extract) {
         string cmd_string="tar -xf "+ap->cx_path2file+".sz";
-        char* cmd=new char[cmd_string.length()];
+        char* cmd=new char[cmd_string.length()+1];
         strcpy(cmd,cmd_string.c_str());
         system(cmd);
         delete []cmd;
     }
-    */
+    
     //wenyu's modification ends
 
     if (ap->to_extract) {  // fp32 only for now
@@ -189,29 +189,30 @@ int main(int argc, char** argv)
     if (ap->to_archive or ap->to_dryrun) {
         //using tar command to encapsulate files with gzip
         string cmd_string="tar -czf "+ap->opath+cx_basename+".sz "+ap->opath+cx_basename+".*";
-        char* cmd=new char[cmd_string.length()];
+        char* cmd=new char[cmd_string.length()+1];
         strcpy(cmd,cmd_string.c_str());
         system(cmd);
+	delete []cmd;
         //remove 5 subfiles
-        /*
+        
         cmd_string="rm "+ap->opath+cx_basename+".hbyte "+ap->opath+cx_basename+".outlier "+ap->opath+cx_basename+".canon "+ap->opath+cx_basename+".hmeta "+ap->opath+cx_basename+".yamp";
-        cmd=new char[cmd_string.length()];
+        cmd=new char[cmd_string.length()+1];
         strcpy(cmd,cmd_string.c_str());
         system(cmd);
-        */
+        
         delete []cmd;
     }
 
     //if it's decompression, remove released subfiles at last.
-    /*
+    
     if (ap->to_extract) {
         string cmd_string="rm "+ap->cx_path2file+".hbyte "+ap->cx_path2file+".outlier "+ap->cx_path2file+".canon "+ap->cx_path2file+".hmeta "+ap->cx_path2file+".yamp";
-        char* cmd=new char[cmd_string.length()];
+        char* cmd=new char[cmd_string.length()+1];
         strcpy(cmd,cmd_string.c_str());
         system(cmd);
         delete []cmd;
     }
-    */
+    
     //wenyu's modification ends
     
 }


### PR DESCRIPTION
add 1 to length of char* cmd to avoid array access out of boundary, this will eliminate "double free or corruption (!prev)" error during compression.