### PR TITLE
modify decompression input path format

### DIFF
--- a/src/argparse.cc
+++ b/src/argparse.cc
@@ -907,6 +907,8 @@ void ArgPack::SortOutFilenames()
     // (2) "./fname"        -> "./" "fname"
     // (3) "/path/to/fname" -> "/path/to", "fname"
     auto cx_input_path = cx_path2file.substr(0, cx_path2file.rfind("/") + 1);
+    if(to_extract)
+        cx_path2file=cx_path2file.substr(0,cx_path2file.rfind("."));
     auto cx_basename   = cx_path2file.substr(cx_path2file.rfind("/") + 1);
 
     if (opath == "") opath = cx_input_path == "" ? opath = "" : opath = cx_input_path;

--- a/src/cusz.cu
+++ b/src/cusz.cu
@@ -149,9 +149,9 @@ int main(int argc, char** argv)
     if (ap->to_extract) {
         string cmd_string;
 	if(cx_directory.length()==0){
-	    cmd_string = "tar -xf " + ap->cx_path2file + ".sz";
+	    cmd_string = "tar -xf " + ap->cx_path2file+".sz";
 	} else {
-	    cmd_string = "tar -xf " + ap->cx_path2file + ".sz "+" -C "+cx_directory;
+	    cmd_string = "tar -xf " + ap->cx_path2file+".sz" +" -C "+cx_directory;
 	}
         char*  cmd        = new char[cmd_string.length() + 1];
         strcpy(cmd, cmd_string.c_str());


### PR DESCRIPTION
now when specifying input file in decompression process, add suffix ".sz" to the file.