### PR TITLE
patch for large datum (working on V100)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 CCFLAGS   := $(STD) -O3
 NVCCFLAGS := $(STD) $(DEPLOY) --expt-relaxed-constexpr
 
-CCFILES_OMP:=$(SRC_DIR)/types.cc
+CCFILES_OMP:=$(SRC_DIR)/analysis_utils.cc
 CCFILES   := $(filter-out $(CCFILES_OMP), $(wildcard $(SRC_DIR)/*.cc))
 
 MAIN      := $(SRC_DIR)/cusz.cu

--- a/Makefile
+++ b/Makefile
@@ -32,21 +32,24 @@ endif
 CCFLAGS   := $(STD) -O3
 NVCCFLAGS := $(STD) $(DEPLOY) --expt-relaxed-constexpr
 
-CCFILES   := $(wildcard $(SRC_DIR)/*.cc)
+CCFILES_OMP:=$(SRC_DIR)/types.cc
+CCFILES   := $(filter-out $(CCFILES_OMP), $(wildcard $(SRC_DIR)/*.cc))
 
 MAIN      := $(SRC_DIR)/cusz.cu
 CUFILES2  := $(SRC_DIR)/cusz_workflow.cu $(SRC_DIR)/cusz_dualquant.cu
 CUFILES3  := $(SRC_DIR)/canonical.cu $(SRC_DIR)/par_merge.cu $(SRC_DIR)/par_huffman.cu
 CUFILES1  := $(filter-out $(MAIN) $(CUFILES3) $(CUFILES2), $(wildcard $(SRC_DIR)/*.cu))
 
+CCOBJS_OMP:= $(CCFILES_OMP:$(SRC_DIR)/%.cc=$(OBJ_DIR)/%.o)
 CCOBJS    := $(CCFILES:$(SRC_DIR)/%.cc=$(OBJ_DIR)/%.o)
 CUOBJS1   := $(CUFILES1:$(SRC_DIR)/%.cu=$(OBJ_DIR)/%.o)
 CUOBJS2   := $(CUFILES2:$(SRC_DIR)/%.cu=$(OBJ_DIR)/%.o)
 CUOBJS3   := $(CUFILES3:$(SRC_DIR)/%.cu=$(OBJ_DIR)/%.o)
 
 CUOBJS    := $(CUOBJS1) $(CUOBJS2) $(CUOBJS3)
-OBJS      := $(CCOBJS) $(CUOBJS)
+OBJS      := $(CCOBJS) $(CCOBJS_OMP) $(CUOBJS)
 
+$(CCOBJS_OMP): CCFLAGS += -fopenmp
 # $(CUOBJS1): NVCCFLAGS +=
 $(CUOBJS2): NVCCFLAGS += -rdc=true
 $(CUOBJS3): NVCCFLAGS += -rdc=true
@@ -65,7 +68,7 @@ install: bin/cusz
 	cp bin/cusz /usr/local/bin
 
 cusz: $(OBJS) | $(BIN_DIR)
-	$(NVCC) $(NVCCFLAGS) -lcusparse $(MAIN) -rdc=true $^ -o $(BIN_DIR)/$@
+	$(NVCC) $(NVCCFLAGS) -lgomp -lcusparse $(MAIN) -rdc=true $^ -o $(BIN_DIR)/$@
 $(BIN_DIR):
 	mkdir $@
 

--- a/src/SDRB.cc
+++ b/src/SDRB.cc
@@ -27,6 +27,7 @@ size_t dims_QMCPACK1[]    = {288, 69, 7935, 1, 3};
 size_t dims_QMCPACK2[]    = {69, 69, 33120, 1, 3};
 size_t dims_EXAFEL_demo[] = {388, 59200, 1, 1, 2};
 size_t dims_ARAMCO[]      = {235, 849, 849, 1, 3};
+size_t dims_parihaka[]    = {1168, 1126, 922, 1, 3};
 
 size_t* InitializeDemoDims(
     std::string const& datum,
@@ -48,7 +49,9 @@ size_t* InitializeDemoDims(
             {std::string("qmc"), dims_QMCPACK1},
             {std::string("qmcpre"), dims_QMCPACK2},
             {std::string("exafeldemo"), dims_EXAFEL_demo},
-            {std::string("aramco"), dims_ARAMCO}};
+            {std::string("aramco"), dims_ARAMCO},
+            {std::string("parihaka"), dims_parihaka}  //
+        };
 
     auto dims_L16 = new size_t[16]();
     int  BLK;

--- a/src/analysis_utils.cc
+++ b/src/analysis_utils.cc
@@ -1,0 +1,55 @@
+/**
+ * @file analysis_utils.cc
+ * @author Jiannan Tian
+ * @brief
+ * @version 0.1.3
+ * @date 2020-11-04
+ *
+ * (C) 2020 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+#include "analysis_utils.hh"
+#include <iostream>
+#include <tuple>
+
+// not working for now
+template <typename T>
+double GetDatumValueRange(std::string fname, size_t l)
+{
+    auto d = io::ReadBinaryFile<T>(fname, l);
+
+    int idx;
+    int max_val, min_val; /* = 0 not needed according to Jim Cownie comment */
+
+#pragma omp parallel for reduction(max : max_val)
+    for (idx = 0; idx < l; idx++) max_val = max_val > d[idx] ? max_val : d[idx];
+#pragma omp parallel for reduction(min : min_val)
+    for (idx = 0; idx < l; idx++) min_val = min_val < d[idx] ? min_val : d[idx];
+
+    delete[] d;
+    return max_val - min_val;
+}
+
+template double GetDatumValueRange<float>(std::string fname, size_t l);
+template double GetDatumValueRange<double>(std::string fname, size_t l);
+
+template <typename T>
+std::tuple<double, double, double> GetDatumValueRange(T* data, size_t l)
+{
+    int idx;
+    T   max_val = data[0], min_val = data[0]; /* = 0 not needed according to Jim Cownie comment */
+
+    // #pragma omp parallel for reduction(max : max_val) reduction(min : min_val)
+    for (idx = 0; idx < l; idx++) {
+        max_val = max_val > data[idx] ? max_val : data[idx];
+        min_val = min_val < data[idx] ? min_val : data[idx];
+    }
+    // std::cout << max_val << std::endl;
+    // std::cout << min_val << std::endl;
+
+    return {max_val, min_val, max_val - min_val};
+}
+
+template std::tuple<double, double, double> GetDatumValueRange<float>(float*, size_t);
+template std::tuple<double, double, double> GetDatumValueRange<double>(double*, size_t);

--- a/src/analysis_utils.hh
+++ b/src/analysis_utils.hh
@@ -1,0 +1,63 @@
+/**
+ * @file analysis_utils.hh
+ * @author Jiannan Tian
+ * @brief Simple data analysis (header)
+ * @version 0.1.3
+ * @date 2020-11-03
+ *
+ * (C) 2020 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+#ifndef ANALYSIS_UTILS_H
+#define ANALYSIS_UTILS_H
+
+#include <omp.h>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include "io.hh"
+
+template <typename T>
+double GetDatumValueRange(std::string fname, size_t l);
+
+template <typename T>
+std::tuple<double, double, double> GetDatumValueRange(T* data, size_t l);
+
+namespace cusz {
+namespace impl {
+
+inline size_t GetEdgeOfReinterpretedSquare(size_t l) { return static_cast<size_t>(ceil(sqrt(l))); };
+
+}  // namespace impl
+}  // namespace cusz
+
+template <typename T>
+struct AdHocDataPack {
+    T*     data;
+    T*     d_data;
+    size_t len;
+    size_t m;    // padded len, single dimension
+    size_t mxm;  // 2d
+
+    AdHocDataPack(T* data_, T* d_data_, size_t len_)
+    {
+        data      = data_;
+        d_data    = d_data_;
+        len       = len_;
+        this->m   = cusz::impl::GetEdgeOfReinterpretedSquare(len);  // row-major mxn matrix
+        this->mxm = m * m;
+    }
+};
+
+// namespace cusz {
+// namespace analysis {
+
+// template <typename T>
+// double GetDatumRange(T* d_data);
+
+// }  // namespace analysis
+// }  // namespace cusz
+
+#endif

--- a/src/argparse.cc
+++ b/src/argparse.cc
@@ -323,7 +323,7 @@ ArgPack::cuszFullDoc()
         "                Use demo dataset, will omit given dimension(s). Supported datasets include:\n"
         "                1D: _hacc_  _hacc1g_  _hacc4g_\n"
         "                2D: _cesm_  _exafeldemo_\n"
-        "                3D: _hurricane_  _nyx_  _qmc_  _qmcpre_  _aramco_\n"
+        "                3D: _hurricane_  _nyx_  _qmc_  _qmcpre_  _aramco_  _parihaka_\n"
         "\n"
         "    *Internal* (will be automated with configuration when going public)\n"
         "        *-Q* or *--*@q@*uant-rep* or *--bcode-bitwidth* <8|16|32>\n"
@@ -450,7 +450,10 @@ ArgPack::ArgPack(int argc, char** argv, bool huffman)
                     if (string(argv[i]) == "--huffman-rep") goto _HUFFMANCODE;
                     if (string(argv[i]) == "--huffman-chunk") goto _HUFFMANCHUNKSIZE;
                     if (string(argv[i]) == "--dict-size") goto _DICT;
-                    if (string(argv[i]) == "--gzip") {to_gzip=true; break;}  //wenyu: if there is "--gzip", set member field to_gzip true
+                    if (string(argv[i]) == "--gzip") {
+                        to_gzip = true;
+                        break;
+                    }  // wenyu: if there is "--gzip", set member field to_gzip true
                 // work
                 // ----------------------------------------------------------------
                 case 'e':
@@ -581,27 +584,28 @@ ArgPack::ArgPack(int argc, char** argv)
         exit(0);
     }
     // default values
-    dict_size      = 1024;
-    quant_rep      = 16;
-    huffman_rep    = 32;
-    huffman_chunk  = 512;
-    n_dim          = -1;
-    d0             = 1;
-    d1             = 1;
-    d2             = 1;
-    d3             = 1;
-    mantissa       = 1.23;
-    exponent       = -4.56;
-    to_archive     = false;
-    to_extract     = false;
-    use_demo       = false;
-    verbose        = false;
-    to_verify      = false;
-    verify_huffman = false;
-    skip_huffman   = false;
-    skip_writex    = false;
-    pre_binning    = false;
-    to_dryrun      = false;
+    dict_size              = 1024;
+    quant_rep              = 16;
+    huffman_rep            = 32;
+    huffman_chunk          = 512;
+    n_dim                  = -1;
+    d0                     = 1;
+    d1                     = 1;
+    d2                     = 1;
+    d3                     = 1;
+    mantissa               = 1.23;
+    exponent               = -4.56;
+    to_archive             = false;
+    to_extract             = false;
+    use_demo               = false;
+    verbose                = false;
+    to_verify              = false;
+    verify_huffman         = false;
+    skip_huffman           = false;
+    skip_writex            = false;
+    pre_binning            = false;
+    to_dryrun              = false;
+    autotune_huffman_chunk = true;
 
     opath = "";
 
@@ -677,7 +681,8 @@ ArgPack::ArgPack(int argc, char** argv)
                         break;
                     }
                     if (string(argv[i]) == "--gzip") {
-                        to_gzip=true; break;  //wenyu: if there is "--gzip", set member field to_gzip true
+                        to_gzip = true;
+                        break;  // wenyu: if there is "--gzip", set member field to_gzip true
                     }
                     // if (string(argv[i]) == "--coname") {
                     //     // TODO does not apply for preprocessed such as binning
@@ -822,7 +827,10 @@ ArgPack::ArgPack(int argc, char** argv)
                     break;
                 case 'C':
                 _HUFFMANCHUNKSIZE:
-                    if (i + 1 <= argc) huffman_chunk = str2int(argv[++i]);
+                    if (i + 1 <= argc) {  //
+                        huffman_chunk          = str2int(argv[++i]);
+                        autotune_huffman_chunk = false;
+                    }
                     break;
                 // error bound
                 // ----------------------------------------------------------------
@@ -907,9 +915,8 @@ void ArgPack::SortOutFilenames()
     // (2) "./fname"        -> "./" "fname"
     // (3) "/path/to/fname" -> "/path/to", "fname"
     auto cx_input_path = cx_path2file.substr(0, cx_path2file.rfind("/") + 1);
-    if(to_extract)
-        cx_path2file=cx_path2file.substr(0,cx_path2file.rfind("."));
-    auto cx_basename   = cx_path2file.substr(cx_path2file.rfind("/") + 1);
+    if (to_extract) cx_path2file = cx_path2file.substr(0, cx_path2file.rfind("."));
+    auto cx_basename = cx_path2file.substr(cx_path2file.rfind("/") + 1);
 
     if (opath == "") opath = cx_input_path == "" ? opath = "" : opath = cx_input_path;
     opath += "/";

--- a/src/argparse.cc
+++ b/src/argparse.cc
@@ -382,11 +382,12 @@ ArgPack::ArgPack(int argc, char** argv, bool huffman)
         exit(0);
     }
     // default values
-    dict_size       = 1024;
-    input_rep       = 16;
-    huffman_datalen = -1;  // TODO argcheck
-    huffman_rep     = 32;
-    huffman_chunk   = 512;
+    dict_size        = 1024;
+    input_rep        = 16;
+    huffman_datalen  = -1;  // TODO argcheck
+    huffman_rep      = 32;
+    huffman_chunk    = 512;
+    read_args_status = 0;
 
     n_dim = -1;
     d0    = 1;
@@ -606,6 +607,7 @@ ArgPack::ArgPack(int argc, char** argv)
     pre_binning            = false;
     to_dryrun              = false;
     autotune_huffman_chunk = true;
+    read_args_status       = 0;
 
     opath = "";
 

--- a/src/argparse.hh
+++ b/src/argparse.hh
@@ -45,6 +45,7 @@ typedef struct ArgPack {
     int    n_dim, d0, d1, d2, d3;
     double mantissa, exponent;
     bool   to_archive, to_extract, to_dryrun;
+    bool   autotune_huffman_chunk;
     bool   use_demo;
     bool   verbose;
     bool   to_verify;
@@ -58,7 +59,7 @@ typedef struct ArgPack {
     bool to_decode;        // for standalone huffman
     bool get_entropy;      // for standalone huffman (not in use)
     bool to_gzip;          // wenyu: whether to do a gzip lossless compression on encoded data
-    
+
     static string format(const string& s);
 
     int trap(int _status);

--- a/src/autotune.cu
+++ b/src/autotune.cu
@@ -1,0 +1,95 @@
+/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file autotune.cu
+ * modified by Jiannan Tian
+ * @brief autotune kernel launch parameter, esp. naive Huffman enc. deflating
+ * @version 0.1.3
+ * @date 2020-11-03
+ *
+ */
+
+#include <cuda_runtime.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "autotune.h"
+
+// taken from `cuda-samples/Common/helper_cuda.h`
+// Beginning of GPU Architecture definitions
+inline int _ConvertSMVer2Cores(int major, int minor)
+{
+    // Defines for GPU Architecture types (using the SM version to determine
+    // the # of cores per SM
+    typedef struct {
+        int SM;  // 0xMm (hexidecimal notation), M = SM Major version,
+        // and m = SM minor version
+        int Cores;
+    } sSMtoCores;
+
+    sSMtoCores nGpuArchCoresPerSM[] = {{0x30, 192}, {0x32, 192}, {0x35, 192}, {0x37, 192}, {0x50, 128}, {0x52, 128},
+                                       {0x53, 128}, {0x60, 64},  {0x61, 128}, {0x62, 128}, {0x70, 64},  {0x72, 64},
+                                       {0x75, 64},  {0x80, 64},  {0x86, 128}, {-1, -1}};
+
+    int index = 0;
+
+    while (nGpuArchCoresPerSM[index].SM != -1) {
+        if (nGpuArchCoresPerSM[index].SM == ((major << 4) + minor)) { return nGpuArchCoresPerSM[index].Cores; }
+
+        index++;
+    }
+
+    // If we don't find the values, we default use the previous one
+    // to run properly
+    printf(
+        "MapSMtoCores for SM %d.%d is undefined."
+        "  Default to use %d Cores/SM\n",
+        major, minor, nGpuArchCoresPerSM[index - 1].Cores);
+    return nGpuArchCoresPerSM[index - 1].Cores;
+}
+
+/**
+ * @brief Get CUDA core number
+ * modified from `cuda-samples/Samples/deviceQuery/deviceQuery.cpp`
+ * @return size_t
+ */
+size_t cusz::tune::GetCUDACoreNum()
+{
+    int         num_dev  = 0;
+    cudaError_t error_id = cudaGetDeviceCount(&num_dev);
+
+    if (error_id != cudaSuccess) {
+        printf("cudaGetDeviceCount returned %d\n-> %s\n", static_cast<int>(error_id), cudaGetErrorString(error_id));
+        exit(EXIT_FAILURE);
+    }
+    if (num_dev == 0) { printf("NO CUDA device detected.\n"); }
+    cudaSetDevice(0);
+    cudaDeviceProp dev_prop;
+    cudaGetDeviceProperties(&dev_prop, 0);
+    return _ConvertSMVer2Cores(dev_prop.major, dev_prop.minor) * dev_prop.multiProcessorCount;
+}

--- a/src/autotune.h
+++ b/src/autotune.h
@@ -1,0 +1,24 @@
+/**
+ * @file autotune.h
+ * @author Jiannan Tian
+ * @brief called as if a plain CPU function
+ * @version 0.1.3
+ * @date 2020-11-03
+ *
+ * (C) 2020 by Washington State University, Argonne National Laboratory
+ *
+ */
+
+#ifndef AUTOTUNE_H
+#define AUTOTUNE_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace cusz {
+namespace tune {
+size_t GetCUDACoreNum();
+}
+}  // namespace cusz
+
+#endif

--- a/src/cusz.cu
+++ b/src/cusz.cu
@@ -99,10 +99,13 @@ int main(int argc, char** argv)
         auto mxm = m * m;
 
         cout << log_dbg << "original len:\t" << len << " (padding: " << m << ")" << endl;
+        auto a = hires::now();
         CHECK_CUDA(cudaMallocHost(&data, mxm * sizeof(T)));
         memset(data, mxm * sizeof(T), 0x00);
         io::ReadBinaryFile<T>(ap->cx_path2file, data, len);
-        T* d_data = mem::CreateDeviceSpaceAndMemcpyFromHost(data, mxm);
+        T*   d_data = mem::CreateDeviceSpaceAndMemcpyFromHost(data, mxm);
+        auto z      = hires::now();
+        cout << log_dbg << "Time loading data:\t" << static_cast<duration_t>(z - a).count() << "s" << endl;
 
         adp = new AdHocDataPack<T>(data, d_data, len);
 

--- a/src/cusz.cu
+++ b/src/cusz.cu
@@ -262,6 +262,8 @@ int main(int argc, char** argv)
     // invoke system() function to merge and compress the resulting 5 files after cusz compression
     string cx_basename = ap->cx_path2file.substr(ap->cx_path2file.rfind("/") + 1);
     if (ap->to_archive or ap->to_dryrun) {
+        auto tar_a = hires::now();
+
         // remove *.sz if existing
         string cmd_string = "rm -rf " + ap->opath + cx_basename + ".sz";
         char*  cmd        = new char[cmd_string.length() + 1];
@@ -284,9 +286,10 @@ int main(int argc, char** argv)
 
         cmd = new char[cmd_string.length() + 1];
         strcpy(cmd, cmd_string.c_str());
+
         system(cmd);
+
         delete[] cmd;
-        cout << log_info << "Written to:\t\e[1m" << ap->opath << cx_basename << ".sz\e[0m" << endl;
 
         // remove 5 subfiles
         cmd_string = "rm -rf " + ap->opath + cx_basename + ".hbyte " + ap->opath + cx_basename + ".outlier " +
@@ -295,6 +298,11 @@ int main(int argc, char** argv)
         cmd = new char[cmd_string.length() + 1];
         strcpy(cmd, cmd_string.c_str());
         system(cmd);
+
+        auto tar_z = hires::now();
+        cout << log_dbg << "Time tar'ing\t" << static_cast<duration_t>(tar_z - tar_a).count() << "s" << endl;
+        cout << log_info << "Written to:\t\e[1m" << ap->opath << cx_basename << ".sz\e[0m" << endl;
+
         delete[] cmd;
     }
 

--- a/src/cusz_dualquant.cu
+++ b/src/cusz_dualquant.cu
@@ -36,8 +36,8 @@ const int RADIUS = 14;
 // const size_t EBx2   = 2;
 const size_t EBx2_r = 3;
 
-extern __constant__ int    symb_dims[16];
-extern __constant__ double symb_ebs[4];
+// extern __constant__ int    symb_dims[16];
+// extern __constant__ double symb_ebs[4];
 
 template <typename T, typename Q, int B>
 __global__ void cusz::PdQ::c_lorenzo_1d1l(T* data, Q* code, size_t const* dims, double const* precisions)
@@ -57,24 +57,24 @@ __global__ void cusz::PdQ::c_lorenzo_1d1l(T* data, Q* code, size_t const* dims, 
     code[id] = quantizable * _code;
 }
 
-// no new1
-template <typename T, typename Q, int B>
-__global__ void cusz::PdQ::c_lorenzo_1d1l_cmem(T* data, Q* code)
-{
-    auto   x    = threadIdx.x;
-    size_t id   = blockIdx.x * blockDim.x + threadIdx.x;
-    auto   s1df = reinterpret_cast<T*>(scratch);
-    if (id >= symb_dims[DIM0]) return;
-    // prequantization
-    s1df[x] = round(data[id] * symb_ebs[EBx2_r]);  // maintain fp representation
-    __syncthreads();
-    // postquantization
-    T    posterror   = s1df[x] - (x != 0 ? s1df[x - 1] : 0);
-    bool quantizable = fabs(posterror) < symb_dims[RADIUS];
-    __syncthreads();
-    data[id] = (1 - quantizable) * s1df[x];  // data array as outlier
-    code[id] = quantizable * static_cast<Q>(posterror + symb_dims[RADIUS]);
-}
+// // no new1
+// template <typename T, typename Q, int B>
+// __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem(T* data, Q* code)
+// {
+//     auto   x    = threadIdx.x;
+//     size_t id   = blockIdx.x * blockDim.x + threadIdx.x;
+//     auto   s1df = reinterpret_cast<T*>(scratch);
+//     if (id >= symb_dims[DIM0]) return;
+//     // prequantization
+//     s1df[x] = round(data[id] * symb_ebs[EBx2_r]);  // maintain fp representation
+//     __syncthreads();
+//     // postquantization
+//     T    posterror   = s1df[x] - (x != 0 ? s1df[x - 1] : 0);
+//     bool quantizable = fabs(posterror) < symb_dims[RADIUS];
+//     __syncthreads();
+//     data[id] = (1 - quantizable) * s1df[x];  // data array as outlier
+//     code[id] = quantizable * static_cast<Q>(posterror + symb_dims[RADIUS]);
+// }
 
 template <typename T, typename Q, int B>
 __global__ void cusz::PdQ::c_lorenzo_2d1l(T* data, Q* code, size_t const* dims, double const* precisions)
@@ -128,29 +128,29 @@ __global__ void cusz::PdQ::c_lorenzo_2d1l_new(T* data, Q* code)
 }
  */
 
-template <typename T, typename Q, int B>
-__global__ void cusz::PdQ::c_lorenzo_2d1l_cmem(T* data, Q* code)
-{
-    auto y   = threadIdx.y;
-    auto x   = threadIdx.x;
-    auto gi1 = blockIdx.y * blockDim.y + y;
-    auto gi0 = blockIdx.x * blockDim.x + x;
+// template <typename T, typename Q, int B>
+// __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem(T* data, Q* code)
+// {
+//     auto y   = threadIdx.y;
+//     auto x   = threadIdx.x;
+//     auto gi1 = blockIdx.y * blockDim.y + y;
+//     auto gi0 = blockIdx.x * blockDim.x + x;
 
-    T(&s2df)[B][B] = *reinterpret_cast<T(*)[B][B]>(&scratch);
-    if (gi0 >= symb_dims[DIM0] or gi1 >= symb_dims[DIM1]) return;
-    size_t id = gi0 + gi1 * symb_dims[DIM0];  // low to high dim, inner to outer
-    // prequantization
-    s2df[y][x] = round(data[id] * symb_ebs[EBx2_r]);  // fp representation
-    __syncthreads();
-    // postquantization
-    T posterror = s2df[y][x]                       //
-                  - (x == 0 ? 0 : s2df[y][x - 1])  //
-                  - (y == 0 ? 0 : s2df[y - 1][x])  //
-                  + (x > 0 and y > 0 ? s2df[y - 1][x - 1] : 0);
-    bool quantizable = fabs(posterror) < symb_dims[RADIUS];
-    code[id]         = quantizable * static_cast<Q>(posterror + symb_dims[RADIUS]);
-    data[id]         = (1 - quantizable) * s2df[y][x];  // data array as outlier
-}
+//     T(&s2df)[B][B] = *reinterpret_cast<T(*)[B][B]>(&scratch);
+//     if (gi0 >= symb_dims[DIM0] or gi1 >= symb_dims[DIM1]) return;
+//     size_t id = gi0 + gi1 * symb_dims[DIM0];  // low to high dim, inner to outer
+//     // prequantization
+//     s2df[y][x] = round(data[id] * symb_ebs[EBx2_r]);  // fp representation
+//     __syncthreads();
+//     // postquantization
+//     T posterror = s2df[y][x]                       //
+//                   - (x == 0 ? 0 : s2df[y][x - 1])  //
+//                   - (y == 0 ? 0 : s2df[y - 1][x])  //
+//                   + (x > 0 and y > 0 ? s2df[y - 1][x - 1] : 0);
+//     bool quantizable = fabs(posterror) < symb_dims[RADIUS];
+//     code[id]         = quantizable * static_cast<Q>(posterror + symb_dims[RADIUS]);
+//     data[id]         = (1 - quantizable) * s2df[y][x];  // data array as outlier
+// }
 
 template <typename T, typename Q, int B>
 __global__ void cusz::PdQ::c_lorenzo_3d1l(T* data, Q* code, size_t const* dims, double const* precisions)
@@ -232,37 +232,37 @@ data array as outlier
 }
  */
 
-template <typename T, typename Q, int B>
-__global__ void cusz::PdQ::c_lorenzo_3d1l_cmem(T* data, Q* code)
-{
-    auto z   = threadIdx.z;
-    auto y   = threadIdx.y;
-    auto x   = threadIdx.x;
-    auto gi2 = blockIdx.z * blockDim.z + z;
-    auto gi1 = blockIdx.y * blockDim.y + y;
-    auto gi0 = blockIdx.x * blockDim.x + x;
+// template <typename T, typename Q, int B>
+// __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem(T* data, Q* code)
+// {
+//     auto z   = threadIdx.z;
+//     auto y   = threadIdx.y;
+//     auto x   = threadIdx.x;
+//     auto gi2 = blockIdx.z * blockDim.z + z;
+//     auto gi1 = blockIdx.y * blockDim.y + y;
+//     auto gi0 = blockIdx.x * blockDim.x + x;
 
-    T(&s3df)[B][B][B] = *reinterpret_cast<T(*)[B][B][B]>(&scratch);
+//     T(&s3df)[B][B][B] = *reinterpret_cast<T(*)[B][B][B]>(&scratch);
 
-    if (gi0 >= symb_dims[DIM0] or gi1 >= symb_dims[DIM1] or gi2 >= symb_dims[DIM2]) return;
-    size_t id =
-        gi0 + gi1 * symb_dims[DIM0] + gi2 * symb_dims[DIM0] * symb_dims[DIM1];  // low to high dim, inner to outer
-    // prequantization
-    s3df[z][y][x] = round(data[id] * symb_ebs[EBx2_r]);  // fp representation
-    __syncthreads();
-    // postquantization
-    T    posterror   = s3df[z][y][x] - (                                                                //
-                                      (z > 0 and y > 0 and x > 0 ? s3df[z - 1][y - 1][x - 1] : 0)  // dist=3
-                                      - (y > 0 and x > 0 ? s3df[z][y - 1][x - 1] : 0)              // dist=2
-                                      - (z > 0 and x > 0 ? s3df[z - 1][y][x - 1] : 0)              //
-                                      - (z > 0 and y > 0 ? s3df[z - 1][y - 1][x] : 0)              //
-                                      + (x > 0 ? s3df[z][y][x - 1] : 0)                            // dist=1
-                                      + (y > 0 ? s3df[z][y - 1][x] : 0)                            //
-                                      + (z > 0 ? s3df[z - 1][y][x] : 0));                          //
-    bool quantizable = fabs(posterror) < symb_dims[RADIUS];
-    code[id]         = quantizable * static_cast<Q>(posterror + symb_dims[RADIUS]);
-    data[id]         = (1 - quantizable) * s3df[z][y][x];  // data array as outlier
-}
+//     if (gi0 >= symb_dims[DIM0] or gi1 >= symb_dims[DIM1] or gi2 >= symb_dims[DIM2]) return;
+//     size_t id =
+//         gi0 + gi1 * symb_dims[DIM0] + gi2 * symb_dims[DIM0] * symb_dims[DIM1];  // low to high dim, inner to outer
+//     // prequantization
+//     s3df[z][y][x] = round(data[id] * symb_ebs[EBx2_r]);  // fp representation
+//     __syncthreads();
+//     // postquantization
+//     T    posterror   = s3df[z][y][x] - (                                                                //
+//                                       (z > 0 and y > 0 and x > 0 ? s3df[z - 1][y - 1][x - 1] : 0)  // dist=3
+//                                       - (y > 0 and x > 0 ? s3df[z][y - 1][x - 1] : 0)              // dist=2
+//                                       - (z > 0 and x > 0 ? s3df[z - 1][y][x - 1] : 0)              //
+//                                       - (z > 0 and y > 0 ? s3df[z - 1][y - 1][x] : 0)              //
+//                                       + (x > 0 ? s3df[z][y][x - 1] : 0)                            // dist=1
+//                                       + (y > 0 ? s3df[z][y - 1][x] : 0)                            //
+//                                       + (z > 0 ? s3df[z - 1][y][x] : 0));                          //
+//     bool quantizable = fabs(posterror) < symb_dims[RADIUS];
+//     code[id]         = quantizable * static_cast<Q>(posterror + symb_dims[RADIUS]);
+//     data[id]         = (1 - quantizable) * s3df[z][y][x];  // data array as outlier
+// }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //   ^                 decompression |
@@ -438,17 +438,17 @@ template __global__ void
 cusz::PdQ::x_lorenzo_3d1l<float, uint32_t, 8>(float*, float*, uint32_t*, size_t const*, double);
 
 // c using const mem
-template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint8__t, 32>(float*, uint8__t*);
-template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint16_t, 32>(float*, uint16_t*);
-template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint32_t, 32>(float*, uint32_t*);
-template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint8__t, 64>(float*, uint8__t*);
-template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint16_t, 64>(float*, uint16_t*);
-template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint32_t, 64>(float*, uint32_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint8__t, 32>(float*, uint8__t*);
+// template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint16_t, 32>(float*, uint16_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint32_t, 32>(float*, uint32_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint8__t, 64>(float*, uint8__t*);
+// template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint16_t, 64>(float*, uint16_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_1d1l_cmem<float, uint32_t, 64>(float*, uint32_t*);
 
-template __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem<float, uint8__t, 16>(float*, uint8__t*);
-template __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem<float, uint16_t, 16>(float*, uint16_t*);
-template __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem<float, uint32_t, 16>(float*, uint32_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem<float, uint8__t, 16>(float*, uint8__t*);
+// template __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem<float, uint16_t, 16>(float*, uint16_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_2d1l_cmem<float, uint32_t, 16>(float*, uint32_t*);
 
-template __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem<float, uint8__t, 8>(float*, uint8__t*);
-template __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem<float, uint16_t, 8>(float*, uint16_t*);
-template __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem<float, uint32_t, 8>(float*, uint32_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem<float, uint8__t, 8>(float*, uint8__t*);
+// template __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem<float, uint16_t, 8>(float*, uint16_t*);
+// template __global__ void cusz::PdQ::c_lorenzo_3d1l_cmem<float, uint32_t, 8>(float*, uint32_t*);

--- a/src/cusz_workflow.cu
+++ b/src/cusz_workflow.cu
@@ -230,6 +230,7 @@ void cusz::impl::VerifyHuffman(
 template <typename T, typename Q, typename H>
 void cusz::workflow::Compress(
     argpack* ap,
+    T*       d_data,
     size_t*  dims_L16,
     double*  ebs_L4,
     int&     nnz_outlier,
@@ -238,23 +239,24 @@ void cusz::workflow::Compress(
     size_t&  huffman_metadata_size)
 {
     // TODO to use a struct
+    // TODO already calculated outside in main()
     size_t len = dims_L16[LEN];
     auto   m   = cusz::impl::GetEdgeOfReinterpretedSquare(len);  // row-major mxn matrix
     auto   mxm = m * m;
 
-    cout << log_dbg << "original len:\t" << len << " (padding: " << m << ")" << endl;
+    // hires_clock_t time_a, time_z;
+    // time_a = hires::now();  // load from disk
 
-    hires_clock_t time_a, time_z;
-
-    time_a = hires::now();  // load from disk
+    /* moved loading out to main() */
     // auto data = new T[mxm]();
     // change to pinned memory
-    T* data = nullptr;
-    CHECK_CUDA(cudaMallocHost(&data, mxm * sizeof(T)));
-    io::ReadBinaryFile<T>(ap->cx_path2file, data, len);
-    T* d_data = mem::CreateDeviceSpaceAndMemcpyFromHost(data, mxm);
-    time_z    = hires::now();
-    cout << log_dbg << "Time loading from disk:\t" << static_cast<duration_t>(time_z - time_a).count() << "s" << endl;
+    // T* data = nullptr;
+    // CHECK_CUDA(cudaMallocHost(&data, mxm * sizeof(T)));
+    // io::ReadBinaryFile<T>(ap->cx_path2file, data, len);
+    // T* d_data = mem::CreateDeviceSpaceAndMemcpyFromHost(data, mxm);
+    // time_z    = hires::now();
+    // cout << log_dbg << "Time loading from disk:\t" << static_cast<duration_t>(time_z - time_a).count() << "s" <<
+    // endl;
 
     if (ap->to_dryrun) {
         cout << "\n" << log_info << "Commencing dry-run..." << endl;
@@ -298,7 +300,7 @@ void cusz::workflow::Compress(
 
     cout << log_info << "Compression finished, saved Huffman encoded quant.code.\n";
 
-    cudaFreeHost(data);
+    // cudaFreeHost(data);
     // delete[] data;
     cudaFree(d_bcode);
 }

--- a/src/cusz_workflow.cu
+++ b/src/cusz_workflow.cu
@@ -22,9 +22,12 @@
 #include <cstdlib>
 #include <exception>
 #include <iostream>
-#include <type_traits>
 #include <typeinfo>
 
+// #if __cplusplus >= 201103L
+
+#include <type_traits>
+#include "analysis_utils.hh"
 #include "argparse.hh"
 #include "autotune.h"
 #include "constants.hh"
@@ -229,20 +232,20 @@ void cusz::impl::VerifyHuffman(
 
 template <typename T, typename Q, typename H>
 void cusz::workflow::Compress(
-    argpack* ap,
-    T*       d_data,
-    size_t*  dims_L16,
-    double*  ebs_L4,
-    int&     nnz_outlier,
-    size_t&  n_bits,
-    size_t&  n_uInt,
-    size_t&  huffman_metadata_size)
+    argpack*                 ap,
+    struct AdHocDataPack<T>* adp,
+    size_t*                  dims_L16,
+    double*                  ebs_L4,
+    int&                     nnz_outlier,
+    size_t&                  n_bits,
+    size_t&                  n_uInt,
+    size_t&                  huffman_metadata_size)
 {
     // TODO to use a struct
     // TODO already calculated outside in main()
     size_t len = dims_L16[LEN];
-    auto   m   = cusz::impl::GetEdgeOfReinterpretedSquare(len);  // row-major mxn matrix
-    auto   mxm = m * m;
+    // auto   m   = cusz::impl::GetEdgeOfReinterpretedSquare(len);  // row-major mxn matrix
+    // auto   mxm = m * m;
 
     // hires_clock_t time_a, time_z;
     // time_a = hires::now();  // load from disk
@@ -257,6 +260,11 @@ void cusz::workflow::Compress(
     // time_z    = hires::now();
     // cout << log_dbg << "Time loading from disk:\t" << static_cast<duration_t>(time_z - time_a).count() << "s" <<
     // endl;
+
+    auto data   = adp->data;
+    auto d_data = adp->d_data;
+    auto m      = adp->m;
+    auto mxm    = adp->mxm;
 
     if (ap->to_dryrun) {
         cout << "\n" << log_info << "Commencing dry-run..." << endl;
@@ -420,14 +428,42 @@ void cusz::workflow::Decompress(
     cudaFree(d_bcode);
 }
 
-template void
-cusz::workflow::Compress<float, uint8__t, uint32_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
-template void
-cusz::workflow::Compress<float, uint8__t, uint64_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
-template void
-cusz::workflow::Compress<float, uint16_t, uint32_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
-template void
-cusz::workflow::Compress<float, uint16_t, uint64_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
+template void cusz::workflow::Compress<float, uint8__t, uint32_t>(
+    argpack*,
+    struct AdHocDataPack<float>*,
+    size_t*,
+    double*,
+    int&,
+    size_t&,
+    size_t&,
+    size_t&);
+template void cusz::workflow::Compress<float, uint8__t, uint64_t>(
+    argpack*,
+    struct AdHocDataPack<float>*,
+    size_t*,
+    double*,
+    int&,
+    size_t&,
+    size_t&,
+    size_t&);
+template void cusz::workflow::Compress<float, uint16_t, uint32_t>(
+    argpack*,
+    struct AdHocDataPack<float>*,
+    size_t*,
+    double*,
+    int&,
+    size_t&,
+    size_t&,
+    size_t&);
+template void cusz::workflow::Compress<float, uint16_t, uint64_t>(
+    argpack*,
+    struct AdHocDataPack<float>*,
+    size_t*,
+    double*,
+    int&,
+    size_t&,
+    size_t&,
+    size_t&);
 
 template void
 cusz::workflow::Decompress<float, uint8__t, uint32_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
@@ -437,3 +473,5 @@ template void
 cusz::workflow::Decompress<float, uint16_t, uint32_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
 template void
 cusz::workflow::Decompress<float, uint16_t, uint64_t>(argpack*, size_t*, double*, int&, size_t&, size_t&, size_t&);
+
+// #endif

--- a/src/cusz_workflow.cuh
+++ b/src/cusz_workflow.cuh
@@ -15,6 +15,7 @@
  */
 
 #include <iostream>
+#include "analysis_utils.hh"
 #include "argparse.hh"
 
 using namespace std;
@@ -24,13 +25,14 @@ namespace workflow {
 
 template <typename T, typename Q, typename H>
 void Compress(
-    argpack* ap,
-    size_t*  dims_L16,
-    double*  ebs_L4,
-    int&     nnz_outlier,
-    size_t&  n_bits,
-    size_t&  n_uInt,
-    size_t&  huffman_metadata_size);
+    argpack*                 ap,
+    struct AdHocDataPack<T>* adp,
+    size_t*                  dims_L16,
+    double*                  ebs_L4,
+    int&                     nnz_outlier,
+    size_t&                  n_bits,
+    size_t&                  n_uInt,
+    size_t&                  huffman_metadata_size);
 
 template <typename T, typename Q, typename H>
 void Decompress(
@@ -45,8 +47,6 @@ void Decompress(
 }  // namespace workflow
 
 namespace impl {
-
-inline size_t GetEdgeOfReinterpretedSquare(size_t l) { return static_cast<size_t>(ceil(sqrt(l))); };
 
 template <typename T, typename Q>
 void PdQ(T*, Q*, size_t*, double*);

--- a/src/huffman_workflow.cu
+++ b/src/huffman_workflow.cu
@@ -38,6 +38,7 @@
 #include "huffman_codec.cuh"
 #include "huffman_workflow.cuh"
 #include "par_huffman.cuh"
+#include "timer.hh"
 #include "types.hh"
 
 int ht_state_num;
@@ -216,6 +217,7 @@ std::tuple<size_t, size_t, size_t> HuffmanEncode(string& f_in, Q* d_in, size_t l
             dH_uInt_meta[i] * sizeof(H),  // len in H-uint
             cudaMemcpyDeviceToHost);
     }
+    auto time_a = hires::now();
     // dump bit_meta and uInt_meta
     io::WriteArrayToBinary(f_in + ".hmeta", h_meta + n_chunk, (2 * n_chunk));
     // write densely Huffman code and its metadata
@@ -226,6 +228,9 @@ std::tuple<size_t, size_t, size_t> HuffmanEncode(string& f_in, Q* d_in, size_t l
         reinterpret_cast<uint8_t*>(decode_meta),           //
         sizeof(H) * (2 * type_bw) + sizeof(Q) * dict_size  // first, entry, reversed dict (keys)
     );
+    auto time_z = hires::now();
+    cout << log_dbg << "Time writing Huff. binary:\t" << static_cast<duration_t>(time_z - time_a).count() << "s"
+         << endl;
 
     size_t metadata_size = (2 * n_chunk) * sizeof(decltype(h_meta))              //
                            + sizeof(H) * (2 * type_bw) + sizeof(Q) * dict_size;  // uint8_t

--- a/src/types.cc
+++ b/src/types.cc
@@ -32,34 +32,6 @@
 
 using namespace std;
 
-// TODO still redundant considering 2-time loading data
-template <typename T>
-double GetDatumValueRange(string fname, size_t l)
-{
-    auto d = io::ReadBinaryFile<T>(fname, l);
-    // T    max_ = *std::max_element(d, d + l);
-    // T    min_ = *std::min_element(d, d + l);
-    // T max_ = d[0], min_ = d[0];
-    // for (auto i = 1; i < l; i++) {
-    //     max_ = d[i] > max_ ? d[i] : max_;
-    //     min_ = d[i] < min_ ? d[i] : min_;
-    // }
-
-    int idx;
-    int max_val, min_val; /* = 0 not needed according to Jim Cownie comment */
-
-#pragma omp parallel for reduction(max : max_val)
-    for (idx = 0; idx < l; idx++) max_val = max_val > d[idx] ? max_val : d[idx];
-#pragma omp parallel for reduction(min : min_val)
-    for (idx = 0; idx < l; idx++) min_val = min_val < d[idx] ? min_val : d[idx];
-
-    delete[] d;
-    return max_val - min_val;
-}
-
-template double GetDatumValueRange<float>(string fname, size_t l);
-template double GetDatumValueRange<double>(string fname, size_t l);
-
 size_t* InitializeDims(size_t cap, size_t n_dims, size_t dim0, size_t dim1, size_t dim2, size_t dim3)
 {
     auto dims_L16 = new size_t[16]();

--- a/src/types.hh
+++ b/src/types.hh
@@ -32,9 +32,6 @@
 
 using namespace std;
 
-template <typename T>
-double GetDatumValueRange(string fname, size_t l);
-
 size_t* InitializeDims(size_t cap, size_t n_dims, size_t dim0, size_t dim1 = 1, size_t dim2 = 1, size_t dim3 = 1);
 
 void SetDims(size_t* dims_L16, size_t new_dims[4]);


### PR DESCRIPTION
Zip to show time breakdown,
```
> time ./bin/cusz -f32 -m r2r -e 1e-4 -i ~/Parihaka_PSTM_far_stack.f32 -D parihaka -z

[info] datum:		/path/to/Parihaka_PSTM_far_stack.f32 (4850339584 bytes) of type f32
[dbg]  original len:	1212584896 (padding: 34823)
[dbg]  Time loading data:	1.69805s
[info] quant.cap:	1024	input eb:	0.0001
[dbg]  Time inspecting data range:	0.0119826s
[info] eb change:	(input eb) x 12342.2 (rng) = 1.23422 (relative-to-range)
[dbg]  2-byte quant type, 4-byte internal Huff type

[info] Commencing compression...
[info] nnz.outlier:	16607	(0.00136955%)
[dbg]  Optimal Huffman deflating chunksize	32768
[info] entropy:		3.85809
[dbg]  Huffman enc:	#chunk=37006, chunksze=32768 => 212269553 4-byte words/6792051551 bits
[dbg]  Time writing Huff. binary:	0.730165s
[info] Compression finished, saved Huffman encoded quant.code.
[dbg]  Time tar'ing	1.1637s
[info] Written to:	/path/to//Parihaka_PSTM_far_stack.f32.sz
./bin/cusz -f32 -m r2r -e 1e-4 -i ~/Parihaka_PSTM_far_stack.f32 -D parihaka -  1.24s user 2.80s system 70% cpu 5.687 total
```
5.687s in total, (time loading + write Huff. bin + tar) for 3.592s. Thus, **2.095s** for "real" cuSZ, including CUDA runtime init, CUDA malloc host (currently very long, around **1 second**) + compute kernels. Kernels scale differently, at datum of 5GB, cuSPARSE doesn't seem to scale well.

Unzip to verify,
```
> ./bin/cusz -i ~/Parihaka_PSTM_far_stack.f32.sz -x --origin ~/Parihaka_PSTM_far_stack.f32 --skip write.x

[info] Commencing decompression...
[info] Huffman decoding into quant.code.
[info] Extracted outlier from CSR format.
[info] Decompression finished.

[info] Huffman metadata of chunking and reverse codebook size (in bytes): 594400
[info] Huffman coded output size: 849078212
[info] To compare with the original datum

[info] Verification start ---------------------
| min.val             -6893.359375
| max.val             5448.8828125
| val.rng             12342.2421875
| max.err.abs.val     1.2342529296875
| max.err.abs.idx     86493
| max.err.vs.rng      0.00010000232623352093317
| max.pw.rel.err      1
| PSNR                84.882560160759624068
| NRMSE               5.6999624146827599324E-05
| correl.coeff        0.99999687790253855013
| comp.ratio.w/o.gzip 5.706653
[info] Verification end -----------------------

[info] Decompressed file is written to /path/to/Parihaka_PSTM_far_stack.f32.szx.
[info] Please use compressed data (*.sz) to calculate final comp ratio (w/ gzip).
[info] Skipped writing unzipped to filesystem.
```