### PR TITLE
CMAKE: add install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(cusz_asap CUDA CXX)
+project(cusz CXX CUDA)
+
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CXX_STANDARD 14)
+set(BUILD_SHARED_LIBS OFF)
+
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
 ## This is a feature as of cmake 3.18.
 ## check `cmake --help-policy CMP0104` for more detail.
@@ -11,23 +17,30 @@ set(CMAKE_CXX_STANDARD 14)
 ## For command line, use, for example `cmake -DCMAKE_CUDA_ARCHITECTURES="75" ..` 
 ## to specify CUDA arch.
 
-enable_language(CUDA)
-
 #include_directories(src)
 #include_directories(src/pSZ)
 
 ## TODO flag only add to a specific library, e.g. suppressing deprecation on CUDA10 cuSPARSE
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda --expt-relaxed-constexpr -Wno-deprecated-declarations")
 
-set(LIB_TYPE STATIC)
-
-add_library(pq ${LIB_TYPE} src/wrapper/extrap_lorenzo.cu)
-add_library(argp ${LIB_TYPE} src/context.cc)
-add_library(sp ${LIB_TYPE} src/wrapper/csr11.cu src/wrapper/spgs.cu)
+add_library(pq src/wrapper/extrap_lorenzo.cu)
+add_library(argp src/context.cc)
+add_library(sp src/wrapper/csr11.cu src/wrapper/spgs.cu)
 target_link_libraries(sp -lcusparse)
-add_library(huff ${LIB_TYPE} src/wrapper/huffman_parbook.cu src/wrapper/huffman_coarse.cu)
+add_library(huff src/wrapper/huffman_parbook.cu src/wrapper/huffman_coarse.cu)
 set_target_properties(huff PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-add_library(nvgpusz ${LIB_TYPE} src/default_path.cu src/base_cusz.cu)
+add_library(nvgpusz src/default_path.cu src/base_cusz.cu)
 
 add_executable(cusz src/cusz.cu)
 target_link_libraries(cusz nvgpusz argp huff sp pq)
+
+
+include(GNUInstallDirs)
+
+install(TARGETS pq argp sp huff nvgpusz cusz EXPORT cusz)
+export(EXPORT cusz NAMESPACE CUSZ::
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/cuSZ-targets.cmake)
+install(EXPORT cusz
+  FILE cuSZ-targets.cmake
+  NAMESPACE CUSZ::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cuSZ)


### PR DESCRIPTION
@jtian0 here is a first attempt to allow `cmake --install`. One question before we move forward, we need to expose some of the headers for the users (like I) which intent to use this library programmatically (as opposed as using the given binary).

In order to do this I need the list of headers that we need to install in the users machine.
