### PR TITLE
use standard cmake variable name for building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,7 @@ if(CUSZ_BUILD_EXAMPLES)
   add_subdirectory(example)
 endif()
 
-option(CUSZ_BUILD_TESTS "build test codes" OFF)
-if (CUSZ_BUILD_TESTS)
+if (BUILD_TESTING)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
This allows spack to automatically run the tests for cuSZ.

@jtian0   As an asside, the test suite is somewhat minimal.  LibPressio runs some basic tests (tries to compress a set of 2d and 3d datasets with various error bounds with otherwise default settings), but cuSZ should probably also have some stand alone tests beyond just the sparse codec.