### PR TITLE
Fixing Clock Rate error for CUDA 13

### DIFF
--- a/psz/src/utils/verinfo_nv.cu
+++ b/psz/src/utils/verinfo_nv.cu
@@ -101,10 +101,20 @@ void CUDA_devices()
     cudaDeviceProp deviceProp;
     cudaGetDeviceProperties(&deviceProp, dev);
 
+    int memClockKHz = 0;
+
+    // From CUDAD 13 onwards, the memoryClockRate field of cudaDeviceProp
+    // is deprecated. Use cudaDeviceGetAttribute() instead.
+    #if CUDART_VERSION >= 13000
+        cudaDeviceGetAttribute(&memClockKHz, cudaDevAttrMemoryClockRate, dev);
+    #else
+        memClockKHz = deviceProp.memoryClockRate;
+    #endif
+
     auto membw_GiBps = membw_base1024(
-        deviceProp.memoryBusWidth, deviceProp.memoryClockRate * 1e3);
-    auto membw_GBps = membw_base1000(
-        deviceProp.memoryBusWidth, deviceProp.memoryClockRate * 1e3);
+        deviceProp.memoryBusWidth, memClockKHz * 1e3);
+    auto membw_GBps  = membw_base1000(
+        deviceProp.memoryBusWidth, memClockKHz * 1e3);
 
     printf("- %s\n", deviceProp.name);
     printf(


### PR DESCRIPTION
When building cuSZ for CUDA 13, I got an error regarding the memory clock inside the verinfo_nv.cu file. This error consisted of the field cudaDeviceProp.memoryClockRate not being found on CUDA 13, as it was apparently deprecated. 

As such, I updated the call for cudaDevieGetAttribute, but I also kept deviceProp.memoryClockRate for older CUDA versions.  